### PR TITLE
cddl_gen.py: Place typedefs in a separate file so they can be shared

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -13,10 +13,15 @@
 #
 # Add generated code to the project for decoding CBOR.
 #
+# REQUIRED arguments:
 # <cddl_file> is a file with CDDL data describing the expected CBOR data.
 #
 # <entry_types> is a list of the types defined in the CDDL file for which there
 #               should be an exposed decoding function.
+#
+# OPTIONAL arguments:
+# Specify either DECODE or ENCODE, to generate code for decoding or encoding,
+# respectively. If neither is provided, default to DECODE.
 #
 # Specify VERBOSE to print more information while parsing the CDDL, and add
 # printing to the generated code and decoding library.
@@ -43,6 +48,10 @@ function(target_cddl_source target cddl_file)
   endif()
 
   cmake_parse_arguments(CDDL "DECODE;ENCODE;VERBOSE;CANONICAL" "TYPE_FILE_NAME" "ENTRY_TYPES" ${ARGN})
+
+  if ((NOT CDDL_ENTRY_TYPES) OR (CDDL_ENCODE AND CDDL_DECODE))
+    message(FATAL_ERROR "Missing arguments or illegal combination of arguments.")
+  endif()
 
   if (CDDL_ENCODE)
     set(code "encode")

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -8,7 +8,8 @@
 #                    <cddl_file>
 #                    ENTRY_TYPES <entry_types>
 #                    DECODE|ENCODE
-#                    [VERBOSE] [CANONICAL])
+#                    [VERBOSE] [CANONICAL]
+#                    [TYPE_FILE_NAME <filename>])
 #
 # Add generated code to the project for decoding CBOR.
 #
@@ -22,6 +23,9 @@
 #
 # Specify CANONICAL to make the encoder generate canonical CBOR. This can make
 # code size slightly bigger. This option has no effect together with DECODE.
+#
+# If provided, TYPE_FILE_NAME can be used to specify what the file containing
+# typedefs should be called.
 #
 # The result of the function is that a library is added to the project which
 # contains the generated decoding code. The code is generated at build time
@@ -38,7 +42,7 @@ function(target_cddl_source target cddl_file)
     message(FATAL_ERROR "CDDL input file ${cddl_file} does not exist.")
   endif()
 
-  cmake_parse_arguments(CDDL "DECODE;ENCODE;VERBOSE;CANONICAL" "" "ENTRY_TYPES" ${ARGN})
+  cmake_parse_arguments(CDDL "DECODE;ENCODE;VERBOSE;CANONICAL" "TYPE_FILE_NAME" "ENTRY_TYPES" ${ARGN})
 
   if (CDDL_ENCODE)
     set(code "encode")
@@ -50,6 +54,10 @@ function(target_cddl_source target cddl_file)
   set(c_file ${CMAKE_CURRENT_BINARY_DIR}/${name}_${code}.c)
   set(h_file_dir ${CMAKE_CURRENT_BINARY_DIR}/zephyr/include/generated)
   set(h_file ${h_file_dir}/${name}_${code}.h)
+
+  if (DEFINED CDDL_TYPE_FILE_NAME)
+    set(type_file_arg --oht ${h_file_dir}/${CDDL_TYPE_FILE_NAME})
+  endif()
 
   if ("${CDDL_DECODE}" STREQUAL "${CDDL_ENCODE}")
     message(FATAL_ERROR "Please specify exactly one of DECODE or ENCODE")
@@ -64,6 +72,7 @@ function(target_cddl_source target cddl_file)
     -i ${cddl_path}
     --oc ${c_file}
     --oh ${h_file}
+    ${type_file_arg}
     -t ${CDDL_ENTRY_TYPES}
     $<$<BOOL:${CDDL_DECODE}>:-d>
     $<$<BOOL:${CDDL_ENCODE}>:-e>

--- a/scripts/cddl_gen.py
+++ b/scripts/cddl_gen.py
@@ -9,7 +9,7 @@ from regex import match, search, sub, findall, S, M
 from pprint import pformat, pprint
 from os import path, linesep, makedirs
 from collections import defaultdict
-from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from argparse import ArgumentParser, RawDescriptionHelpFormatter, FileType
 from datetime import datetime
 from copy import copy
 
@@ -1519,13 +1519,13 @@ referencing types, since the C type cannot be self referencing.
 This script requires 'regex' for lookaround functionality not present in 're'.''',
         formatter_class=RawDescriptionHelpFormatter)
 
-    parser.add_argument("-i", "--input", required=True, type=str,
+    parser.add_argument("-i", "--input", required=True, type=FileType('r'),
                         help="Path to input CDDL file.")
-    parser.add_argument("--output-c", "--oc", required=True, type=str,
+    parser.add_argument("--output-c", "--oc", required=True, type=FileType('w'),
                         help="Path to output C file.")
-    parser.add_argument("--output-h", "--oh", required=True, type=str,
+    parser.add_argument("--output-h", "--oh", required=True, type=FileType('w'),
                         help="Path to output header file.")
-    parser.add_argument("--output-h-types", "--oht", required=False, type=str,
+    parser.add_argument("--output-h-types", "--oht", required=False, type=FileType('w'),
                         help="Path to output header file with typedefs (shared between decode and encode).")
     parser.add_argument(
         "-t",
@@ -1705,9 +1705,8 @@ def main():
 
     # Read CDDL file. my_types will become a dict {name:str => definition:str}
     # for all types in the CDDL file.
-    print ("Parsing " + args.input)
-    with open(args.input, 'r') as f:
-        my_types = get_types(strip_comments(f.read()))
+    print ("Parsing " + args.input.name)
+    my_types = get_types(strip_comments(args.input.read()))
 
     # Parse the definitions, replacing the each string with a
     # CodeGenerator instance.
@@ -1742,27 +1741,27 @@ def main():
     u_types = unique_types(sorted_types)
 
     # Create and populate the generated c and h file.
-    makedirs("./" + path.dirname(args.output_c), exist_ok=True)
-    with open(args.output_c, 'w') as f:
-        print ("Writing to " + args.output_c)
-        f.write(render_c_file(functions=u_funcs, header_file_name=path.basename(args.output_h),
-                              entry_types=entry_types, print_time=args.time_header))
-    makedirs("./" + path.dirname(args.output_h), exist_ok=True)
-    type_file_path = args.output_h_types or path.join(path.split(args.output_h)[0], f"types_{path.split(args.output_h)[1]}")
-    type_file_name = path.basename(type_file_path)
-    with open(args.output_h, 'w') as f:
-        print("Writing to " + args.output_h)
-        f.write(render_h_file(type_def_file=type_file_name,
-                              header_guard=path.basename(args.output_h).replace(".", "_").replace("-", "_").upper()
-                                           + "__",
-                              entry_types=entry_types, print_time=args.time_header))
+    makedirs("./" + path.dirname(args.output_c.name), exist_ok=True)
 
-    with open(type_file_path, 'w') as f:
-        print("Writing to " + type_file_name)
-        f.write(render_type_file(type_defs=u_types,
-                              header_guard=path.basename(type_file_name).replace(".", "_").replace("-", "_").upper()
-                                           + "__",
-                              print_time=args.time_header))
+    print ("Writing to " + args.output_c.name)
+    args.output_c.write(render_c_file(functions=u_funcs, header_file_name=path.basename(args.output_h.name),
+                            entry_types=entry_types, print_time=args.time_header))
+
+    makedirs("./" + path.dirname(args.output_h.name), exist_ok=True)
+    type_file = args.output_h_types or open(path.join(path.split(args.output_h.name)[0], f"types_{path.split(args.output_h.name)[1]}"), 'w')
+    type_file_name = path.basename(type_file.name)
+
+    print("Writing to " + args.output_h.name)
+    args.output_h.write(render_h_file(type_def_file=type_file_name,
+                            header_guard=path.basename(args.output_h.name).replace(".", "_").replace("-", "_").upper()
+                                        + "__",
+                            entry_types=entry_types, print_time=args.time_header))
+
+    print("Writing to " + type_file_name)
+    type_file.write(render_type_file(type_defs=u_types,
+                            header_guard=path.basename(type_file_name).replace(".", "_").replace("-", "_").upper()
+                                        + "__",
+                            print_time=args.time_header))
 
 
 if __name__ == "__main__":

--- a/tests/cbor_encode/test1_suit/CMakeLists.txt
+++ b/tests/cbor_encode/test1_suit/CMakeLists.txt
@@ -17,6 +17,7 @@ target_cddl_source(app manifest3.cddl
   ENCODE
   ${VERBOSE}
   ${CANONICAL}
+  TYPE_FILE_NAME manifest3_types.h
   )
 
 target_cddl_source(app manifest3.cddl
@@ -27,6 +28,7 @@ target_cddl_source(app manifest3.cddl
   DECODE
   ${VERBOSE}
   ${CANONICAL}
+  TYPE_FILE_NAME manifest3_types.h
   )
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/cbor_encode/test1_suit/src/main.c
+++ b/tests/cbor_encode/test1_suit/src/main.c
@@ -6,22 +6,7 @@
 
 #include <ztest.h>
 #include "manifest3_decode.h"
-
-
-bool cbor_encode_SUIT_Outer_Wrapper(
-		const uint8_t * p_payload, size_t payload_len,
-		SUIT_Outer_Wrapper_t * p_result,
-		size_t *p_payload_len_out);
-
-bool cbor_encode_SUIT_Command_Sequence(
-		const uint8_t * p_payload, size_t payload_len,
-		SUIT_Command_Sequence_t * p_result,
-		size_t *p_payload_len_out);
-
-bool cbor_encode_SUIT_Authentication_Wrapper(
-		const uint8_t * p_payload, size_t payload_len,
-		SUIT_Authentication_Wrapper_t * p_result,
-		size_t *p_payload_len_out);
+#include "manifest3_encode.h"
 
 /* draft-ietf-suit-manifest-02 Example 0 */
 uint8_t test_vector0_02[] = {


### PR DESCRIPTION
between encoding and decoding.

This fixes #11 