### PR TITLE
Start using the string result for cbor encoded bstrs

### DIFF
--- a/include/cbor_decode.h
+++ b/include/cbor_decode.h
@@ -114,7 +114,7 @@ bool uintx32_expect_union(cbor_state_t * p_state, uint32_t result);
  * @retval true   Header decoded correctly
  * @retval false  Header decoded incorrectly, or backup failed.
  */
-bool bstrx_cbor_start_decode(cbor_state_t *p_state);
+bool bstrx_cbor_start_decode(cbor_state_t *p_state, cbor_string_type_t *p_result);
 
 /** Finalize decoding a CBOR-encoded bstr.
  *

--- a/include/cbor_encode.h
+++ b/include/cbor_encode.h
@@ -33,7 +33,7 @@ bool uintx32_encode(cbor_state_t * p_state, const uint32_t *p_result);
  * @retval true   Header encoded correctly
  * @retval false  Header encoded incorrectly, or backup failed.
  */
-bool bstrx_cbor_start_encode(cbor_state_t *p_state);
+bool bstrx_cbor_start_encode(cbor_state_t *p_state, const cbor_string_type_t *p_result);
 
 /** Finalize encoding a CBOR-encoded BSTR.
  *

--- a/src/cbor_decode.c
+++ b/src/cbor_decode.c
@@ -234,11 +234,9 @@ static bool strx_start_decode(cbor_state_t * p_state,
 	return true;
 }
 
-bool bstrx_cbor_start_decode(cbor_state_t *p_state)
+bool bstrx_cbor_start_decode(cbor_state_t *p_state, cbor_string_type_t *p_result)
 {
-	cbor_string_type_t value;
-
-	if(!strx_start_decode(p_state, &value, CBOR_MAJOR_TYPE_BSTR)) {
+	if(!strx_start_decode(p_state, p_result, CBOR_MAJOR_TYPE_BSTR)) {
 		FAIL();
 	}
 
@@ -246,7 +244,7 @@ bool bstrx_cbor_start_decode(cbor_state_t *p_state)
 		FAIL();
 	}
 
-	p_state->p_payload_end = value.value + value.len;
+	p_state->p_payload_end = p_result->value + p_result->len;
 	return true;
 }
 

--- a/src/cbor_encode.c
+++ b/src/cbor_encode.c
@@ -178,7 +178,7 @@ static size_t remaining_str_len(cbor_state_t *p_state)
 }
 
 
-bool bstrx_cbor_start_encode(cbor_state_t *p_state)
+bool bstrx_cbor_start_encode(cbor_state_t *p_state, const cbor_string_type_t *p_result)
 {
 	if (!new_backup(p_state, 0)) {
 		FAIL();


### PR DESCRIPTION
It was unused as of now, but it can be useful to have it pointing
to the actual string when decoding, e.g. for calculating hash.

For encoding, use the string as input instead of the structure
if the string's value is not NULL.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>