### PR TITLE
Format code to Zephyr standard

### DIFF
--- a/include/cbor_decode.h
+++ b/include/cbor_decode.h
@@ -88,7 +88,7 @@
  *                element count was exhausted, or the value was larger than can
  *                fit in the result variable.
  */
-bool intx32_decode(cbor_state_t * p_state, int32_t *p_result);
+bool intx32_decode(cbor_state_t *p_state, int32_t *p_result);
 
 /** Expect a PINT/NINT with a certain value. Uses intx32_decode internally.
  *
@@ -99,12 +99,12 @@ bool intx32_decode(cbor_state_t * p_state, int32_t *p_result);
  * @retval false  If intx32_decode failed or the result doesn't have the
  *                expected value.
  */
-bool intx32_expect(cbor_state_t * p_state, int32_t result);
+bool intx32_expect(cbor_state_t *p_state, int32_t result);
 
 /** Decode a PINT. */
-bool uintx32_decode(cbor_state_t * p_state, uint32_t *p_result);
-bool uintx32_expect(cbor_state_t * p_state, uint32_t result);
-bool uintx32_expect_union(cbor_state_t * p_state, uint32_t result);
+bool uintx32_decode(cbor_state_t *p_state, uint32_t *p_result);
+bool uintx32_expect(cbor_state_t *p_state, uint32_t result);
+bool uintx32_expect_union(cbor_state_t *p_state, uint32_t result);
 
 /** Decode and consume a BSTR header.
  *
@@ -123,12 +123,12 @@ bool bstrx_cbor_start_decode(cbor_state_t *p_state, cbor_string_type_t *p_result
 bool bstrx_cbor_end_decode(cbor_state_t *p_state);
 
 /** Decode and consume a BSTR */
-bool bstrx_decode(cbor_state_t * p_state, cbor_string_type_t *p_result);
-bool bstrx_expect(cbor_state_t * p_state, cbor_string_type_t *p_result);
+bool bstrx_decode(cbor_state_t *p_state, cbor_string_type_t *p_result);
+bool bstrx_expect(cbor_state_t *p_state, cbor_string_type_t *p_result);
 
 /** Decode and consume a TSTR */
-bool tstrx_decode(cbor_state_t * p_state, cbor_string_type_t *p_result);
-bool tstrx_expect(cbor_state_t * p_state, cbor_string_type_t *p_result);
+bool tstrx_decode(cbor_state_t *p_state, cbor_string_type_t *p_result);
+bool tstrx_expect(cbor_state_t *p_state, cbor_string_type_t *p_result);
 
 /** Decode and consume a LIST header.
  *
@@ -138,10 +138,10 @@ bool tstrx_expect(cbor_state_t * p_state, cbor_string_type_t *p_result);
  * @retval true   Header decoded correctly
  * @retval false  Header decoded incorrectly, or backup failed.
  */
-bool list_start_decode(cbor_state_t * p_state);
+bool list_start_decode(cbor_state_t *p_state);
 
 /** Decode and consume a MAP header. */
-bool map_start_decode(cbor_state_t * p_state);
+bool map_start_decode(cbor_state_t *p_state);
 
 /** Finalize decoding a LIST
  *
@@ -151,28 +151,28 @@ bool map_start_decode(cbor_state_t * p_state);
  * @retval true   Everything ok.
  * @retval false  Element count not correct.
  */
-bool list_end_decode(cbor_state_t * p_state);
+bool list_end_decode(cbor_state_t *p_state);
 
 /** Finalize decoding a MAP */
-bool map_end_decode(cbor_state_t * p_state);
+bool map_end_decode(cbor_state_t *p_state);
 
 /** Decode a "nil" primitive value. */
-bool nilx_expect(cbor_state_t * p_state, void *p_result);
+bool nilx_expect(cbor_state_t *p_state, void *p_result);
 
 /** Decode a boolean primitive value. */
-bool boolx_decode(cbor_state_t * p_state, bool *p_result);
-bool boolx_expect(cbor_state_t * p_state, bool *p_result);
+bool boolx_decode(cbor_state_t *p_state, bool *p_result);
+bool boolx_expect(cbor_state_t *p_state, bool *p_result);
 
 /** Decode a float */
-bool float_decode(cbor_state_t * p_state, double *p_result);
-bool float_expect(cbor_state_t * p_state, double *p_result);
+bool float_decode(cbor_state_t *p_state, double *p_result);
+bool float_expect(cbor_state_t *p_state, double *p_result);
 
 /** Skip a single element, regardless of type and value. */
-bool any_decode(cbor_state_t * p_state, void *p_result);
+bool any_decode(cbor_state_t *p_state, void *p_result);
 
 /** Decode a tag. */
-bool tag_decode(cbor_state_t * p_state, uint32_t *p_result);
-bool tag_expect(cbor_state_t * p_state, uint32_t result);
+bool tag_decode(cbor_state_t *p_state, uint32_t *p_result);
+bool tag_expect(cbor_state_t *p_state, uint32_t result);
 
 /** Decode 0 or more elements with the same type and constraints.
  *
@@ -221,12 +221,12 @@ bool tag_expect(cbor_state_t * p_state, uint32_t result);
  *                values.
  */
 bool multi_decode(size_t min_decode, size_t max_decode, size_t *p_num_decode,
-		cbor_decoder_t decoder, cbor_state_t * p_state, void *p_result,
+		cbor_decoder_t decoder, cbor_state_t *p_state, void *p_result,
 		size_t result_len);
 
 bool present_decode(size_t *p_present,
 		cbor_decoder_t decoder,
-		cbor_state_t * p_state,
+		cbor_state_t *p_state,
 		void *p_result);
 
 #endif /* CBOR_DECODE_H__ */

--- a/include/cbor_encode.h
+++ b/include/cbor_encode.h
@@ -23,7 +23,7 @@
 bool intx32_encode(cbor_state_t *p_state, const int32_t *p_input);
 
 /** Encode a PINT into a uint32_t. */
-bool uintx32_encode(cbor_state_t * p_state, const uint32_t *p_result);
+bool uintx32_encode(cbor_state_t *p_state, const uint32_t *p_result);
 
 /** Encode a BSTR header.
  *
@@ -42,41 +42,41 @@ bool bstrx_cbor_start_encode(cbor_state_t *p_state, const cbor_string_type_t *p_
 bool bstrx_cbor_end_encode(cbor_state_t *p_state);
 
 /** Encode a BSTR, */
-bool bstrx_encode(cbor_state_t * p_state, const cbor_string_type_t *p_result);
+bool bstrx_encode(cbor_state_t *p_state, const cbor_string_type_t *p_result);
 
 /** Encode a TSTR. */
-bool tstrx_encode(cbor_state_t * p_state, const cbor_string_type_t *p_result);
+bool tstrx_encode(cbor_state_t *p_state, const cbor_string_type_t *p_result);
 
 /** Encode a LIST header.
  *
  * The contents of the list can be decoded via subsequent function calls.
  * A state backup is created to keep track of the element count.
  */
-bool list_start_encode(cbor_state_t * p_state, size_t max_num);
+bool list_start_encode(cbor_state_t *p_state, size_t max_num);
 
 /** Encode a MAP header. */
-bool map_start_encode(cbor_state_t * p_state, size_t max_num);
+bool map_start_encode(cbor_state_t *p_state, size_t max_num);
 
 /** Encode end of a LIST. Do some checks and deallocate backup. */
-bool list_end_encode(cbor_state_t * p_state, size_t max_num);
+bool list_end_encode(cbor_state_t *p_state, size_t max_num);
 
 /** Encode end of a MAP. Do some checks and deallocate backup. */
-bool map_end_encode(cbor_state_t * p_state, size_t max_num);
+bool map_end_encode(cbor_state_t *p_state, size_t max_num);
 
 /** Encode a "nil" primitive value. p_result should be NULL. */
-bool nilx_encode(cbor_state_t * p_state, const void *p_result);
+bool nilx_encode(cbor_state_t *p_state, const void *p_result);
 
 /** Encode a boolean primitive value. */
-bool boolx_encode(cbor_state_t * p_state, const bool *p_result);
+bool boolx_encode(cbor_state_t *p_state, const bool *p_result);
 
 /** Encode a float */
-bool float_encode(cbor_state_t * p_state, double *p_result);
+bool float_encode(cbor_state_t *p_state, double *p_result);
 
 /** Dummy encode "any": Encode a "nil". p_input should be NULL. */
 bool any_encode(cbor_state_t *p_state, void *p_input);
 
 /** Encode a tag. */
-bool tag_encode(cbor_state_t * p_state, uint32_t tag);
+bool tag_encode(cbor_state_t *p_state, uint32_t tag);
 
 /** Encode 0 or more elements with the same type and constraints.
  *
@@ -124,12 +124,12 @@ bool tag_encode(cbor_state_t * p_state, uint32_t tag);
  *                values.
  */
 bool multi_encode(size_t min_encode, size_t max_encode, const size_t *p_num_encode,
-		cbor_encoder_t encoder, cbor_state_t * p_state, const void *p_input,
+		cbor_encoder_t encoder, cbor_state_t *p_state, const void *p_input,
 		size_t result_len);
 
 bool present_encode(const size_t *p_present,
 		cbor_encoder_t encoder,
-		cbor_state_t * p_state,
+		cbor_state_t *p_state,
 		const void *p_input);
 
 #endif /* CBOR_ENCODE_H__ */

--- a/scripts/cddl_gen.py
+++ b/scripts/cddl_gen.py
@@ -102,7 +102,7 @@ def do_flatten(to_flatten, allow_multi=False):
 # Return a code snippet that assigns the value to a variable var_name and
 # returns pointer to the variable, or returns NULL if the value is None.
 def val_or_null(value, var_name):
-    return "(%s=%d, &%s)" % (var_name, value,
+    return "(%s = %d, &%s)" % (var_name, value,
                                 var_name) if value is not None else "NULL"
 
 
@@ -1408,14 +1408,14 @@ class CodeGenerator(CddlParser):
         if self.present_var_condition():
             func, *arguments = self.repeated_single_func(ptr_result = True)
             return (
-                f"present_{mode}(&(%s), (void*)%s, %s)" %
+                f"present_{mode}(&(%s), (void *)%s, %s)" %
                 (self.present_var_access(),
                  func,
                  xcode_args(*arguments),))
         elif self.count_var_condition():
             func, *arguments = self.repeated_single_func(ptr_result = True)
             return (
-                f"multi_{mode}(%s, %s, &%s, (void*)%s, %s, %s)" %
+                f"multi_{mode}(%s, %s, &%s, (void *)%s, %s, %s)" %
                 (self.minQ,
                  self.maxQ,
                  self.count_var_access(),
@@ -1455,8 +1455,8 @@ class CodeGenerator(CddlParser):
     def public_xcode_func_sig(self):
         return f"""
 bool cbor_{self.xcode_func_name()}(
-		{"const " if mode == "decode" else ""}uint8_t * p_payload, size_t payload_len,
-		{"" if mode == "decode" else "const "}{self.type_name()} * {struct_ptr_name()},
+		{"const " if mode == "decode" else ""}uint8_t *p_payload, size_t payload_len,
+		{"" if mode == "decode" else "const "}{self.type_name()} *{struct_ptr_name()},
 		{"size_t *p_payload_len_out"})"""
 
 # Consumes and parses a single CDDL type, returning a
@@ -1624,13 +1624,13 @@ def render_function(xcoder):
     func_name = xcoder
     return f"""
 static bool {xcoder[1]}(
-		cbor_state_t *p_state, {"" if mode == "decode" else "const "}{xcoder[2] if struct_ptr_name() in body else "void"} * {struct_ptr_name()})
+		cbor_state_t *p_state, {"" if mode == "decode" else "const "}{xcoder[2] if struct_ptr_name() in body else "void"} *{struct_ptr_name()})
 {{
-	cbor_print("{ xcoder[1] }\\n");
+	cbor_print(__func__ "\\n");
 	{f"size_t temp_elem_counts[{body.count('p_temp_elem_count')}];" if "p_temp_elem_count" in body else ""}
 	{"size_t *p_temp_elem_count = temp_elem_counts;" if "p_temp_elem_count" in body else ""}
 	{"uint32_t current_list_num;" if "current_list_num" in body else ""}
-	{"uint8_t const * p_payload_bak;" if "p_payload_bak" in body else ""}
+	{"uint8_t const *p_payload_bak;" if "p_payload_bak" in body else ""}
 	{"size_t elem_count_bak;" if "elem_count_bak" in body else ""}
 	{"uint32_t tmp_value;" if "tmp_value" in body else ""}
 	{"cbor_string_type_t tmp_str;" if "tmp_str" in body else ""}
@@ -1639,9 +1639,7 @@ static bool {xcoder[1]}(
 	bool result = ({ body });
 
 	if (!result)
-	{{
 		cbor_trace();
-	}}
 
 	{"p_state->elem_count = temp_elem_counts[0];" if "p_temp_elem_count" in body else ""}
 	return result;

--- a/src/cbor_decode.c
+++ b/src/cbor_decode.c
@@ -60,8 +60,8 @@ do {\
  *          CBOR values are always big-endian, so this function converts from
  *          big to little-endian if necessary (@ref CONFIG_BIG_ENDIAN).
  */
-static bool value_extract(cbor_state_t * p_state,
-		void * const p_result, size_t result_len)
+static bool value_extract(cbor_state_t *p_state,
+		void *const p_result, size_t result_len)
 {
 	cbor_trace();
 	cbor_assert(result_len != 0, "0-length result not supported.\n");
@@ -105,7 +105,7 @@ static bool value_extract(cbor_state_t * p_state,
 }
 
 
-static bool int32_decode(cbor_state_t * p_state, int32_t *p_result)
+static bool int32_decode(cbor_state_t *p_state, int32_t *p_result)
 {
 	uint8_t major_type = MAJOR_TYPE(*p_state->p_payload);
 	uint32_t uint_result;
@@ -134,7 +134,7 @@ static bool int32_decode(cbor_state_t * p_state, int32_t *p_result)
 }
 
 
-bool intx32_decode(cbor_state_t * p_state, int32_t *p_result)
+bool intx32_decode(cbor_state_t *p_state, int32_t *p_result)
 {
 	uint8_t major_type = MAJOR_TYPE(*p_state->p_payload);
 
@@ -144,13 +144,13 @@ bool intx32_decode(cbor_state_t * p_state, int32_t *p_result)
 		FAIL();
 	}
 
-	if (!int32_decode(p_state, p_result)){
+	if (!int32_decode(p_state, p_result)) {
 		FAIL();
 	}
 	return true;
 }
 
-bool intx32_expect(cbor_state_t * p_state, int32_t result)
+bool intx32_expect(cbor_state_t *p_state, int32_t result)
 {
 	int32_t value;
 	if (!intx32_decode(p_state, &value)) {
@@ -164,7 +164,7 @@ bool intx32_expect(cbor_state_t * p_state, int32_t result)
 }
 
 
-static bool uint32_decode(cbor_state_t * p_state, uint32_t *p_result)
+static bool uint32_decode(cbor_state_t *p_state, uint32_t *p_result)
 {
 	if (!value_extract(p_state, p_result, 4)) {
 		FAIL();
@@ -174,7 +174,7 @@ static bool uint32_decode(cbor_state_t * p_state, uint32_t *p_result)
 }
 
 
-bool uintx32_decode(cbor_state_t * p_state, uint32_t *p_result)
+bool uintx32_decode(cbor_state_t *p_state, uint32_t *p_result)
 {
 	uint8_t major_type = MAJOR_TYPE(*p_state->p_payload);
 
@@ -182,13 +182,13 @@ bool uintx32_decode(cbor_state_t * p_state, uint32_t *p_result)
 		/* Value to be read doesn't have the right type. */
 		FAIL();
 	}
-	if (!uint32_decode(p_state, p_result)){
+	if (!uint32_decode(p_state, p_result)) {
 		FAIL();
 	}
 	return true;
 }
 
-bool uintx32_expect(cbor_state_t * p_state, uint32_t result)
+bool uintx32_expect(cbor_state_t *p_state, uint32_t result)
 {
 	uint32_t value;
 	if (!uintx32_decode(p_state, &value)) {
@@ -201,14 +201,14 @@ bool uintx32_expect(cbor_state_t * p_state, uint32_t result)
 	return true;
 }
 
-bool uintx32_expect_union(cbor_state_t * p_state, uint32_t result)
+bool uintx32_expect_union(cbor_state_t *p_state, uint32_t result)
 {
 	union_elem_code(p_state);
 	return uintx32_expect(p_state, result);
 }
 
 
-static bool strx_start_decode(cbor_state_t * p_state,
+static bool strx_start_decode(cbor_state_t *p_state,
 		cbor_string_type_t *p_result, cbor_major_type_t exp_major_type)
 {
 	uint8_t major_type = MAJOR_TYPE(*p_state->p_payload);
@@ -263,7 +263,7 @@ bool bstrx_cbor_end_decode(cbor_state_t *p_state)
 }
 
 
-bool strx_decode(cbor_state_t * p_state, cbor_string_type_t *p_result,
+bool strx_decode(cbor_state_t *p_state, cbor_string_type_t *p_result,
 		cbor_major_type_t exp_major_type)
 {
 	if (!strx_start_decode(p_state, p_result, exp_major_type)) {
@@ -290,25 +290,25 @@ bool strx_expect(cbor_state_t *p_state, cbor_string_type_t *p_result,
 }
 
 
-bool bstrx_decode(cbor_state_t * p_state, cbor_string_type_t *p_result)
+bool bstrx_decode(cbor_state_t *p_state, cbor_string_type_t *p_result)
 {
 	return strx_decode(p_state, p_result, CBOR_MAJOR_TYPE_BSTR);
 }
 
 
-bool bstrx_expect(cbor_state_t * p_state, cbor_string_type_t *p_result)
+bool bstrx_expect(cbor_state_t *p_state, cbor_string_type_t *p_result)
 {
 	return strx_expect(p_state, p_result, CBOR_MAJOR_TYPE_BSTR);
 }
 
 
-bool tstrx_decode(cbor_state_t * p_state, cbor_string_type_t *p_result)
+bool tstrx_decode(cbor_state_t *p_state, cbor_string_type_t *p_result)
 {
 	return strx_decode(p_state, p_result, CBOR_MAJOR_TYPE_TSTR);
 }
 
 
-bool tstrx_expect(cbor_state_t * p_state, cbor_string_type_t *p_result)
+bool tstrx_expect(cbor_state_t *p_state, cbor_string_type_t *p_result)
 {
 	return strx_expect(p_state, p_result, CBOR_MAJOR_TYPE_TSTR);
 }
@@ -376,7 +376,7 @@ bool map_end_decode(cbor_state_t *p_state)
 }
 
 
-static bool primx_decode(cbor_state_t * p_state, uint32_t *p_result)
+static bool primx_decode(cbor_state_t *p_state, uint32_t *p_result)
 {
 	uint8_t major_type = MAJOR_TYPE(*p_state->p_payload);
 
@@ -393,10 +393,10 @@ static bool primx_decode(cbor_state_t * p_state, uint32_t *p_result)
 	return true;
 }
 
-static bool primx_expect(cbor_state_t * p_state, uint32_t result)
+static bool primx_expect(cbor_state_t *p_state, uint32_t result)
 {
 	uint32_t value;
-	if (!primx_decode(p_state, &value)){
+	if (!primx_decode(p_state, &value)) {
 		FAIL();
 	}
 	if (value != result) {
@@ -415,7 +415,7 @@ bool nilx_expect(cbor_state_t *p_state, void *p_result)
 }
 
 
-bool boolx_decode(cbor_state_t * p_state, bool *p_result)
+bool boolx_decode(cbor_state_t *p_state, bool *p_result)
 {
 	uint32_t result;
 
@@ -429,7 +429,7 @@ bool boolx_decode(cbor_state_t * p_state, bool *p_result)
 }
 
 
-bool boolx_expect(cbor_state_t * p_state, bool *p_result)
+bool boolx_expect(cbor_state_t *p_state, bool *p_result)
 {
 	bool value;
 	if (!boolx_decode(p_state, &value)) {
@@ -442,7 +442,7 @@ bool boolx_expect(cbor_state_t * p_state, bool *p_result)
 }
 
 
-bool double_decode(cbor_state_t * p_state, double *p_result)
+bool double_decode(cbor_state_t *p_state, double *p_result)
 {
 	uint8_t major_type = MAJOR_TYPE(*p_state->p_payload);
 
@@ -458,7 +458,7 @@ bool double_decode(cbor_state_t * p_state, double *p_result)
 }
 
 
-bool double_expect(cbor_state_t * p_state, double *p_result)
+bool double_expect(cbor_state_t *p_state, double *p_result)
 {
 	double value;
 	if (!double_decode(p_state, &value)) {
@@ -471,7 +471,7 @@ bool double_expect(cbor_state_t * p_state, double *p_result)
 }
 
 
-bool any_decode(cbor_state_t * p_state, void *p_result)
+bool any_decode(cbor_state_t *p_state, void *p_result)
 {
 	cbor_assert(p_result == NULL,
 			"'any' type cannot be returned, only skipped.\n");
@@ -515,7 +515,7 @@ bool any_decode(cbor_state_t * p_state, void *p_result)
 }
 
 
-bool tag_decode(cbor_state_t * p_state, uint32_t *p_result)
+bool tag_decode(cbor_state_t *p_state, uint32_t *p_result)
 {
 	uint8_t major_type = MAJOR_TYPE(*p_state->p_payload);
 
@@ -531,7 +531,7 @@ bool tag_decode(cbor_state_t * p_state, uint32_t *p_result)
 }
 
 
-bool tag_expect(cbor_state_t * p_state, uint32_t result)
+bool tag_expect(cbor_state_t *p_state, uint32_t result)
 {
 	uint32_t tag_val;
 
@@ -549,7 +549,7 @@ bool multi_decode(size_t min_decode,
 		size_t max_decode,
 		size_t *p_num_decode,
 		cbor_decoder_t decoder,
-		cbor_state_t * p_state,
+		cbor_state_t *p_state,
 		void *p_result,
 		size_t result_len)
 {
@@ -578,7 +578,7 @@ bool multi_decode(size_t min_decode,
 
 bool present_decode(size_t *p_present,
 		cbor_decoder_t decoder,
-		cbor_state_t * p_state,
+		cbor_state_t *p_state,
 		void *p_result)
 {
 	size_t num_decode;

--- a/src/cbor_encode.c
+++ b/src/cbor_encode.c
@@ -46,7 +46,7 @@ static bool encode_header_byte(cbor_state_t *p_state,
 /** Encode a single value.
  */
 static bool value_encode_len(cbor_state_t *p_state, cbor_major_type_t major_type,
-		const void * const p_input, size_t result_len)
+		const void *const p_input, size_t result_len)
 {
 	uint8_t *p_u8_result  = (uint8_t *)p_input;
 
@@ -76,7 +76,7 @@ static bool value_encode_len(cbor_state_t *p_state, cbor_major_type_t major_type
 }
 
 
-static size_t get_result_len(const void * const p_input, size_t max_result_len)
+static size_t get_result_len(const void *const p_input, size_t max_result_len)
 {
 	uint8_t *p_u8_result  = (uint8_t *)p_input;
 
@@ -94,7 +94,7 @@ static size_t get_result_len(const void * const p_input, size_t max_result_len)
 
 
 static bool value_encode(cbor_state_t *p_state, cbor_major_type_t major_type,
-		const void * const p_input, size_t max_result_len)
+		const void *const p_input, size_t max_result_len)
 {
 	cbor_assert(max_result_len != 0, "0-length result not supported.\n");
 	return value_encode_len(p_state, major_type, p_input,
@@ -136,7 +136,7 @@ static bool uint32_encode(cbor_state_t *p_state, const uint32_t *p_input,
 
 bool uintx32_encode(cbor_state_t *p_state, const uint32_t *p_input)
 {
-	if (!uint32_encode(p_state, p_input, CBOR_MAJOR_TYPE_PINT)){
+	if (!uint32_encode(p_state, p_input, CBOR_MAJOR_TYPE_PINT)) {
 		FAIL();
 	}
 	return true;
@@ -364,7 +364,7 @@ bool any_encode(cbor_state_t *p_state, void *p_input)
 }
 
 
-bool tag_encode(cbor_state_t * p_state, uint32_t tag)
+bool tag_encode(cbor_state_t *p_state, uint32_t tag)
 {
 	if (!value_encode(p_state, CBOR_MAJOR_TYPE_TAG, &tag, sizeof(tag))) {
 		FAIL();
@@ -398,7 +398,7 @@ bool multi_encode(size_t min_encode,
 
 bool present_encode(const size_t *p_present,
 		cbor_encoder_t encoder,
-		cbor_state_t * p_state,
+		cbor_state_t *p_state,
 		const void *p_input)
 {
 	size_t num_encode = *p_present;


### PR DESCRIPTION
This was mostly the case, just fixed some stray errors.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

Note: Not tested against checkpatch yet.